### PR TITLE
handle duplicate username in user registration endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 *.db
 __pycache__/
+CLAUDE.md

--- a/backend/src/app/repository/user.py
+++ b/backend/src/app/repository/user.py
@@ -14,6 +14,11 @@ class UserRepository:
         return db.query(User).filter(User.email == email).first()
 
     @staticmethod
+    def get_by_username(db: Session, username: str) -> User | None:
+        """Get a user by username."""
+        return db.query(User).filter(User.username == username).first()
+
+    @staticmethod
     def get_by_id(db: Session, user_id: int) -> User | None:
         """Get a user by ID."""
         return db.query(User).filter(User.id == user_id).first()

--- a/backend/src/app/services/user.py
+++ b/backend/src/app/services/user.py
@@ -39,9 +39,13 @@ class UserService:
             )
         return user_id
 
-    def is_user_exists(self, db: Session, email: str) -> bool:
+    def is_email_taken(self, db: Session, email: str) -> bool:
         """Check if a user with the given email already exists in the database."""
         return self.repository.get_by_mail(db, email) is not None
+
+    def is_username_taken(self, db: Session, username: str) -> bool:
+        """Check if a user with the given username already exists in the database."""
+        return self.repository.get_by_username(db, username) is not None
 
     def get_current_user(
         self,
@@ -97,12 +101,15 @@ class UserService:
             HTTPException: If the username or email is already exists.
         """
 
-        # Check if user already exists with the same username or email
-        existing_user = self.is_user_exists(db, user_db.email)
-        if existing_user:
+        if self.is_email_taken(db, user_db.email):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Email already registered",
+            )
+        if self.is_username_taken(db, user_db.username):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Username already taken",
             )
 
         # Hash the password before creating the user

--- a/backend/src/app/tests/unit_tests/user/test_user_repository.py
+++ b/backend/src/app/tests/unit_tests/user/test_user_repository.py
@@ -42,6 +42,26 @@ def test_get_by_mail_not_found(db: Session):
     assert user is None
 
 
+def test_get_by_username_exists(db: Session):
+    # should return user if username exists
+    user_db = UserDB(
+        username="testuser",
+        email="test@example.com",
+        hashed_password="hashedpassword123",
+    )
+    UserRepository.create_user(db, user_db)
+
+    user = UserRepository.get_by_username(db, "testuser")
+    assert user is not None
+    assert user.username == "testuser"
+
+
+def test_get_by_username_not_found(db: Session):
+    # should return None if username does not exist
+    user = UserRepository.get_by_username(db, "nonexistent")
+    assert user is None
+
+
 def test_get_by_id_exists(db: Session):
     # should return user if id exists
     user_db = UserDB(

--- a/backend/src/app/tests/unit_tests/user/test_user_routes.py
+++ b/backend/src/app/tests/unit_tests/user/test_user_routes.py
@@ -2,9 +2,7 @@
 
 from fastapi.testclient import TestClient
 
-
 # Route Tests
-
 
 def test_register_user_success(client: TestClient):
     # hitting POST /users/register with valid data should return 201
@@ -45,6 +43,29 @@ def test_register_duplicate_email(client: TestClient):
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "Email already registered"
+
+
+def test_register_duplicate_username(client: TestClient):
+    # second registration with the same username should return 400
+    client.post(
+        "/users/register",
+        json={
+            "username": "testuser",
+            "email": "first@example.com",
+            "password": "securepassword123",
+        },
+    )
+
+    response = client.post(
+        "/users/register",
+        json={
+            "username": "testuser",
+            "email": "second@example.com",
+            "password": "differentpassword",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Username already taken"
 
 
 def test_register_missing_fields(client: TestClient):


### PR DESCRIPTION
Added get_by_username to the user repository so we can look up users by username. Updated register_user to check if the username or email is already taken before inserting, returning a 400 for each case. Added unit tests to cover duplicate username registration and get_by_username lookups 
closes #73 