### PR TITLE
created docker compose yaml file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Project-root environment file used by docker-compose.yml.
+# Copy this file to `.env` (no extension) and edit values as needed:
+#   cp .env.example .env
+#
+# These values configure the Postgres container. They MUST match the
+# password used in backend/.env's DATABASE_URL, OR the override in
+# docker-compose.yml's `environment:` block (which uses these same vars).
+#
+# Compose reads the project-root .env automatically — no flag needed.
+
+POSTGRES_USER=learning_app
+POSTGRES_PASSWORD=dev_password_123
+POSTGRES_DB=learning_paths

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,24 @@
+# Don't ship the local virtualenv — it's macOS-built and won't run on Linux.
+.venv/
+
+# Python build artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Test/lint caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# Local SQLite leftovers from before the Postgres migration
+*.db
+
+# Secrets — passed in at runtime via env_file in compose.
+.env
+
+# Editor/OS noise
+.DS_Store
+.idea/
+.vscode/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,25 @@
+# uv's official image — Python 3.12 and uv are both pre-installed.
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+# Copy dependency manifests first so this layer caches
+# until pyproject.toml / uv.lock actually change.
+COPY pyproject.toml uv.lock ./
+
+# Install deps into /app/.venv. --frozen forbids touching uv.lock,
+# --no-install-project skips installing the app itself (no source yet).
+RUN uv sync --frozen --no-install-project
+
+# Now bring in the rest of the source and install the project itself.
+# Compose will also bind-mount ./backend over /app for hot reload, but
+# baking source in keeps the image runnable without a mount (e.g. in prod).
+COPY . .
+RUN uv sync --frozen
+
+EXPOSE 8000
+
+# fastapi dev binds to 127.0.0.1 by default — unreachable from outside
+# the container. --host 0.0.0.0 makes it listen on all interfaces so
+# the published port (compose's "8000:8000") actually works.
+CMD ["uv", "run", "fastapi", "dev", "src/app/main.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,88 @@
+# Modern Compose (v2) doesn't need a `version:` field — omitting it
+# uses the latest schema.
+
+services:
+  # ─────────────────────────────────────────────────────────────
+  # PostgreSQL 16 — the database.
+  # On first start it auto-creates POSTGRES_USER + POSTGRES_DB, then
+  # runs anything in /docker-entrypoint-initdb.d/ (our init.sql).
+  # ─────────────────────────────────────────────────────────────
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-learning_app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev_password_123}
+      POSTGRES_DB: ${POSTGRES_DB:-learning_paths}
+    ports:
+      # Publish to host so you can also connect with VS Code's
+      # PostgreSQL extension or `psql` from your Mac.
+      - "5432:5432"
+    volumes:
+      # Named volume → DB data survives `docker compose down`.
+      # To wipe it (e.g. to re-trigger init.sql): `docker compose down -v`
+      - pgdata:/var/lib/postgresql/data
+      # Init script: creates the test database. Read-only mount.
+      - ./docker/postgres-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    healthcheck:
+      # backend's `depends_on` waits for this to pass before starting.
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-learning_app} -d ${POSTGRES_DB:-learning_paths}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ─────────────────────────────────────────────────────────────
+  # FastAPI backend — built from backend/Dockerfile.
+  # ─────────────────────────────────────────────────────────────
+  backend:
+    build:
+      context: ./backend
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      # Loads SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES,
+      # GROQ_API_KEY (and DATABASE_URL, which we override below).
+      - ./backend/.env
+    environment:
+      # Overrides the localhost URL from .env. Inside the container,
+      # "localhost" means the container itself, not your Mac. The DB
+      # is reachable as `db` — that's the service name above.
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-learning_app}:${POSTGRES_PASSWORD:-dev_password_123}@db:5432/${POSTGRES_DB:-learning_paths}
+    ports:
+      - "8000:8000"
+    volumes:
+      # Bind-mount source for hot reload — `fastapi dev` watches files
+      # and reloads on save, even though they live on your Mac.
+      - ./backend:/app
+      # Anonymous volume "shadows" /app/.venv so the host's macOS-built
+      # virtualenv doesn't clobber the container's Linux one.
+      - /app/.venv
+
+  # ─────────────────────────────────────────────────────────────
+  # Next.js frontend — built from frontend/Dockerfile.
+  # ─────────────────────────────────────────────────────────────
+  frontend:
+    build:
+      context: ./frontend
+    depends_on:
+      - backend
+    environment:
+      # Browser-side calls. The browser runs on your Mac, so it sees
+      # the published port at localhost:8000.
+      NEXT_PUBLIC_API_URL: http://localhost:8000
+      # Server-side calls (Next SSR / route handlers). These run inside
+      # the frontend container, where the backend is reachable as `backend`.
+      INTERNAL_API_URL: http://backend:8000
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      # Same anonymous-volume trick: keep container's node_modules and
+      # .next build cache instead of inheriting from the host.
+      - /app/node_modules
+      - /app/.next
+
+# Named volume — Docker manages where this lives on disk. Survives
+# container restarts and `docker compose down`. Wipe with `down -v`.
+volumes:
+  pgdata:

--- a/docker/postgres-init.sql
+++ b/docker/postgres-init.sql
@@ -1,0 +1,7 @@
+-- Runs once, on first startup of a fresh Postgres data volume.
+-- The main database (POSTGRES_DB) and user (POSTGRES_USER) are already
+-- created by the postgres image from env vars; we only need the test DB.
+--
+-- Run as POSTGRES_USER (a superuser), so the test DB is owned by them.
+
+CREATE DATABASE learning_paths_test;

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,22 @@
+# node_modules is huge AND platform-specific — let `bun install` rebuild
+# it inside the Linux container.
+node_modules/
+
+# Next.js build output — should be regenerated inside the container.
+.next/
+out/
+
+# Secrets
+.env
+.env.local
+.env.*.local
+
+# Editor/OS noise
+.DS_Store
+.idea/
+.vscode/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+# Official Bun image. Bun is the package manager (per bun.lock) AND the
+# runtime that executes the Next.js dev server.
+FROM oven/bun:1
+
+WORKDIR /app
+
+# Install deps first for layer caching — only re-runs when manifests change.
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+# Bring in the rest of the source. Compose mounts ./frontend over /app
+# at runtime for hot reload; this COPY makes the image runnable standalone.
+COPY . .
+
+EXPOSE 3000
+
+# Next defaults to listening on all interfaces inside containers, but we
+# pass -H 0.0.0.0 explicitly so behavior doesn't depend on Next's defaults.
+CMD ["bunx", "next", "dev", "-H", "0.0.0.0"]


### PR DESCRIPTION
## Summary

Adds full Docker Compose setup so the project runs with one command: `docker compose up --build`. Replaces the manual psql + database setup steps from the team onboarding doc.

Closes #108

## What's in this PR

- `backend/Dockerfile` — `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` base, runs `fastapi dev` with `--host 0.0.0.0`
- `frontend/Dockerfile` — `oven/bun:1` base, runs `bunx next dev -H 0.0.0.0`
- `docker-compose.yml` at project root — three services (`db`, `backend`, `frontend`) on a shared network
- `docker/postgres-init.sql` — auto-creates `learning_paths_test` on first boot
- `backend/.dockerignore` and `frontend/.dockerignore`
- `.env.example` at project root for compose-level Postgres vars

## Key design choices

- **Postgres 16** runs in a container with a named volume (`pgdata`) so DB data survives `docker compose down`
- **Hot reload** for both services via bind mounts (`./backend:/app`, `./frontend:/app`) plus anonymous volumes to shadow `.venv` and `node_modules` (host's macOS-built binaries don't clobber the container's Linux ones)
- **Healthcheck on `db`** — backend waits via `depends_on: condition: service_healthy` so it never races Postgres on cold start
- **`DATABASE_URL` overridden in compose** to use the `db` service hostname instead of `localhost`; `backend/.env` stays valid for non-Docker local dev

## How to test

```bash
cd Learning-Path-Generator
cp .env.example .env
docker compose up --build
